### PR TITLE
Configure media handling

### DIFF
--- a/myshop/myshop/settings.py
+++ b/myshop/myshop/settings.py
@@ -132,6 +132,9 @@ STATICFILES_DIRS =[
     os.path.join(BASE_DIR, 'static'
                  )]
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+# Media files
+MEDIA_URL = '/media/'
+MEDIA_ROOT = BASE_DIR / 'media'
 # Dfault primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 

--- a/myshop/myshop/urls.py
+++ b/myshop/myshop/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path('', TemplateView.as_view(template_name='index.html')),
 ]
 
+# Serve media files during development
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 


### PR DESCRIPTION
## Summary
- set `MEDIA_URL` and `MEDIA_ROOT`
- serve media files when `DEBUG` is true

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685fc3e1df54832a83d2b31639ed0eb4