### PR TITLE
Add simple URL tests

### DIFF
--- a/myshop/products/tests.py
+++ b/myshop/products/tests.py
@@ -1,3 +1,23 @@
 from django.test import TestCase
 
-# Create your tests here.
+class URLTests(TestCase):
+    def test_root_url(self):
+        response = self.client.get('/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_login_url(self):
+        response = self.client.get('/users/login/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_search_url(self):
+        response = self.client.get('/products/search/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_cart_url(self):
+        response = self.client.get('/cart/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_order_create_url(self):
+        response = self.client.get('/orders/create/')
+        self.assertEqual(response.status_code, 200)
+


### PR DESCRIPTION
## Summary
- implement tests verifying that main URLs return HTTP 200

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685fc3e69624832aa9e9efca8357e507